### PR TITLE
Update minus sign character

### DIFF
--- a/GMStepper/GMStepper.swift
+++ b/GMStepper/GMStepper.swift
@@ -52,8 +52,8 @@ import UIKit
     /// If the value is integer, it is shown without floating point.
     @IBInspectable public var showIntegerIfDoubleIsInteger: Bool = true
 
-    /// Text on the left button. Be sure that it fits in the button. Defaults to "-".
-    @IBInspectable public var leftButtonText: String = "-" {
+    /// Text on the left button. Be sure that it fits in the button. Defaults to "−".
+    @IBInspectable public var leftButtonText: String = "−" {
         didSet {
             leftButton.setTitle(leftButtonText, forState: .Normal)
         }


### PR DESCRIPTION
Use the unicode “minus sign” symbol, instead of the “dash” from the classic keyboard. 

The difference isn’t visible on GitHub, or with most fixed-space fonts, but you can see the result when run on iOS.
