### PR TITLE
Fix potential crash in background

### DIFF
--- a/GMStepper/GMStepper.swift
+++ b/GMStepper/GMStepper.swift
@@ -298,6 +298,7 @@ import UIKit
         backgroundColor = buttonsBackgroundColor
         layer.cornerRadius = cornerRadius
         clipsToBounds = true
+        labelOriginalCenter = label.center
 
         NotificationCenter.default.addObserver(self, selector: #selector(GMStepper.reset), name: NSNotification.Name.UIApplicationWillResignActive, object: nil)
     }


### PR DESCRIPTION
I noticed that views containing GMStepper could cause a crash if the app was sent to the background after the view was initialized (e.g. loaded from nib) but before layoutSubviews() was called (e.g. view displayed). The crash happened on line 407 of reset() when it tried to access a nil implicitly unwrapped optional. Fixed by initializing labelOriginalCenter in setup() rather than waiting for layoutSubviews()