### PR TITLE
Reset timer when button touches are cancelled

### DIFF
--- a/GMStepper/GMStepper.swift
+++ b/GMStepper/GMStepper.swift
@@ -177,6 +177,7 @@ import UIKit
         button.addTarget(self, action: #selector(GMStepper.leftButtonTouchDown), for: .touchDown)
         button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchUpInside)
         button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchUpOutside)
+        button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchCancel)
         return button
     }()
 
@@ -189,6 +190,7 @@ import UIKit
         button.addTarget(self, action: #selector(GMStepper.rightButtonTouchDown), for: .touchDown)
         button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchUpInside)
         button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchUpOutside)
+        button.addTarget(self, action: #selector(GMStepper.buttonTouchUp), for: .touchCancel)
         return button
     }()
 
@@ -298,6 +300,7 @@ import UIKit
         backgroundColor = buttonsBackgroundColor
         layer.cornerRadius = cornerRadius
         clipsToBounds = true
+        labelOriginalCenter = label.center
 
         NotificationCenter.default.addObserver(self, selector: #selector(GMStepper.reset), name: NSNotification.Name.UIApplicationWillResignActive, object: nil)
     }


### PR DESCRIPTION
This fixes a weird behaviour that can happen if you touch and hold one of the buttons then go to a different screen. When you return the current screen that's showing a GMStepper, the value is still counting up/down continuously.