### PR TITLE
Adjustable middle label layer corner radius 

### DIFF
--- a/GMStepper/GMStepper.swift
+++ b/GMStepper/GMStepper.swift
@@ -121,6 +121,13 @@ import UIKit
             label.font = labelFont
         }
     }
+       /// Corner radius of the middle label. Defaults to 0.
+    @IBInspectable public var labelCornerRadius: CGFloat = 0 {
+        didSet {
+            label.layer.cornerRadius = labelCornerRadius
+        
+            }
+    }
 
     /// Corner radius of the stepper's layer. Defaults to 4.0.
     @IBInspectable public var cornerRadius: CGFloat = 4.0 {
@@ -205,6 +212,8 @@ import UIKit
         label.textColor = self.labelTextColor
         label.backgroundColor = self.labelBackgroundColor
         label.font = self.labelFont
+        label.layer.cornerRadius = self.labelCornerRadius
+        label.layer.masksToBounds = true
         label.isUserInteractionEnabled = true
         let panRecognizer = UIPanGestureRecognizer(target: self, action: #selector(GMStepper.handlePan))
         panRecognizer.maximumNumberOfTouches = 1

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var labelBackgroundColor: UIColor = UIColor(red:0.26, green:0.6, blue:0.87, alph
 var labelFont = UIFont(name: "AvenirNext-Bold", size: 25.0)
 
 /// Corner radius of the middle label's layer. Defaults to 0.0.
-var cornerRadius: CGFloat = 0.0
+var labelCornerRadius: CGFloat = 0.0
 
 /// Corner radius of the stepper's layer. Defaults to 4.0.
 var cornerRadius: CGFloat = 4.0

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ var labelBackgroundColor: UIColor = UIColor(red:0.26, green:0.6, blue:0.87, alph
 /// Font of the middle label. Defaults to AvenirNext-Bold, 25.0 points in size.
 var labelFont = UIFont(name: "AvenirNext-Bold", size: 25.0)
 
+/// Corner radius of the middle label's layer. Defaults to 0.0.
+var cornerRadius: CGFloat = 0.0
+
 /// Corner radius of the stepper's layer. Defaults to 4.0.
 var cornerRadius: CGFloat = 4.0
 


### PR DESCRIPTION
I left the default setting to 0.0 so it doesn't effect the default design
![stepper](https://cloud.githubusercontent.com/assets/13803906/25312596/f8764048-2860-11e7-9340-dec0337fa22c.png)
